### PR TITLE
feat: add simple run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 Unified, safe, high-level repo operations for AI agents (e.g., Codex).
 
+## Quickstart
+Run a full repo task with minimal options:
+
+```bash
+codexrt run "Refactor helpers into utils/ and add tests"
+```
+
+Add `--auto-pr` to open a pull request after a successful run.
+
+Python API:
+
+```python
+from codex_repo_tool import run_task
+run_task("Refactor helpers into utils/ and add tests")
+```
+
 ## Goals
 - High-level, atomic operations (search, patch, test, PR)
 - Guardrails before applying changes (lint, tests)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,101 @@
+# Codex Repo Tool — Tutorial
+
+This guide walks agents and developers through the common workflows supported by **codex-repo-tool**. Use it as a step-by-step tutorial when exploring or automating repository maintenance.
+
+## 1. Setup
+
+1. Install the package (already done in this environment):
+   ```bash
+   pip install codex-repo-tool
+   ```
+2. Navigate to a Git repository that you want to operate on.
+
+## 2. One-Line Task Execution
+
+For quick tasks that should handle diff planning, validation, commit and PR automatically:
+
+```bash
+codexrt run --goal "Add tests for src/add.py" --auto-pr
+```
+
+* `--goal` describes the change in natural language.
+* `--auto-pr` (default) opens a pull request when checks pass.
+* The command will refuse to commit if lint or tests fail.
+
+## 3. Full Task Control
+
+When you need more flags or want to run in `dry_run` mode, use the `task` subcommand:
+
+```bash
+codexrt task \
+  --goal "Refactor helpers into utils/" \
+  --hints "src/helpers" "tests" \
+  --dry-run
+```
+
+* `--hints` restricts file discovery.
+* `--dry-run` validates in a temporary worktree without committing.
+* Omit `--dry-run` and add `--branch` to create and push changes.
+
+## 4. Searching the Repository
+
+```bash
+codexrt search "def run_task"
+```
+
+This prints each match with the file path and line number, scanning only source-like files.
+
+## 5. Crafting Patches Manually
+
+1. Propose a patch:
+   ```bash
+   codexrt patch propose <<'DIFF'
+   --- a/README.md
+   +++ b/README.md
+   @@ -1,3 +1,4 @@
+    # Codex Repo Tool
+    Unified repository operations for AI agents.
+   +Added quickstart example.
+   DIFF
+   ```
+2. If the patch applies cleanly you will see a success message.
+3. Apply the stored patch into the working tree:
+   ```bash
+   codexrt patch apply
+   ```
+4. Run validation checks (lint and tests):
+   ```bash
+   codexrt qa
+   ```
+
+## 6. Python API
+
+The same capabilities are available programmatically:
+
+```python
+from codex_repo_tool import run_task, search_code
+
+hits = search_code('def run_task')
+print(hits[0])  # {'path': 'src/codex_repo_tool/task.py', 'line_no': 10, 'line': 'def run_task(...'}
+
+run_task(goal="Update README quickstart", dry_run=True)
+```
+
+`run_task` mirrors the `codexrt run` command, returning a dictionary describing the result.
+
+## 7. Validation Policy
+
+The tool enforces checks defined in `.codexrt/policy.yml`. By default:
+
+- Lint and tests must pass (`require_checks`).
+- Writes to sensitive paths like `.git/` are blocked (`protected_paths`).
+
+Adjust the policy file if your workflow requires different rules.
+
+## 8. Next Steps
+
+- Explore `examples/sample.diff` for a minimal unified diff.
+- Review `README.md` for project overview.
+- Run `codexrt --help` to see all available commands.
+
+This AGENTS file only documents usage; it does not enforce additional rules on files under `docs/`.

--- a/src/codex_repo_tool/__init__.py
+++ b/src/codex_repo_tool/__init__.py
@@ -5,6 +5,7 @@ from .github_api import comment_pr, link_to_issue, list_issues, open_pull_reques
 from .patch import apply_patch, discard_patch, propose_patch
 from .qa import lint_code, run_tests
 from .search import search_code
+from .task import run as run_task
 
 __all__ = [
     "list_files",
@@ -19,4 +20,5 @@ __all__ = [
     "comment_pr",
     "list_issues",
     "link_to_issue",
+    "run_task",
 ]

--- a/src/codex_repo_tool/cli.py
+++ b/src/codex_repo_tool/cli.py
@@ -86,6 +86,12 @@ def main() -> None:
     p_sum = sub.add_parser("summarize", help="Write repo summary map to disk")
     p_sum.add_argument("--root", default=".")
 
+    # simplified task runner
+    p_run = sub.add_parser("run", help="Run a task with minimal options")
+    p_run.add_argument("goal", help="Natural language task objective")
+    p_run.add_argument("--auto-pr", action="store_true", default=False)
+    p_run.add_argument("--model", default=None)
+
     # task orchestrator
     p_task = sub.add_parser("task", help="Plan → validate → (optional) PR")
     p_task.add_argument("--goal", required=True)
@@ -145,6 +151,9 @@ def main() -> None:
         idx = build_index(args.root)
         path = save_repo_map(idx, args.root)
         print(path)
+    elif args.cmd == "run":
+        res = run_task(goal=args.goal, auto_pr=args.auto_pr, model=args.model)
+        print(json.dumps(res, indent=2))
     elif args.cmd == "task":
         res = run_task(
             goal=args.goal,

--- a/src/codex_repo_tool/semantic.py
+++ b/src/codex_repo_tool/semantic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import json
 import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -105,3 +106,11 @@ def dependency_graph(root_or_index: str | Path | dict = ".") -> dict[str, list[s
         return root_or_index.get("deps", {})
     idx = build_index(str(root_or_index))
     return idx.get("deps", {})
+
+
+def save_repo_map(index: dict, root: str = ".") -> str:
+    """Save index to .codexrt/map.json under the given root and return the path."""
+    path = Path(root) / ".codexrt" / "map.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(index), encoding="utf-8")
+    return str(path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,53 @@
+import json
+import sys
+from unittest import mock
+
+from codex_repo_tool import run_task as run_task_alias
+from codex_repo_tool.cli import main
+from codex_repo_tool.task import run as run_task
+
+SAMPLE_DIFF = """--- a/README.md
++++ b/README.md
+@@ -1,3 +1,4 @@
+ # CodexRepoTool
+ 
+ Unified, safe, high-level repo operations for AI agents (e.g., Codex).
++Added by task test.
+"""
+
+
+def test_run_task_alias():
+    assert run_task_alias is run_task
+
+
+@mock.patch("codex_repo_tool.task.open_pull_request")
+@mock.patch("subprocess.run")
+def test_cli_run(mock_run, mock_pr, tmp_path, monkeypatch, capsys):
+    class R:
+        def __init__(self, code=0):
+            self.returncode = code
+            self.stdout = ""
+            self.stderr = ""
+
+    mock_run.return_value = R(0)
+    mock_pr.return_value = {"number": 1}
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / "README.md").write_text(
+        "# CodexRepoTool\n\nUnified, safe, high-level repo operations for AI agents (e.g., Codex).\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        "codex_repo_tool.task.get_diff",
+        lambda goal, ctx, model=None: SAMPLE_DIFF,
+    )
+    monkeypatch.setattr(sys, "argv", ["codexrt", "run", "Append line", "--auto-pr"])
+
+    main()
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["ok"] is True
+    assert "pr" in data


### PR DESCRIPTION
## Summary
- expose `run_task` at package root
- add `codexrt run` for one-line task execution
- document quickstart usage and CLI runner
- add tutorial AGENTS file with step-by-step tool usage

## Testing
- `pip install requests pyyaml -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf2feab7288322bb49b9ac12befd3b