### PR TITLE
feat: include QA outputs in bundle results

### DIFF
--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,3 +1,4 @@
+import subprocess
 from unittest import mock
 
 from codex_repo_tool.patch import apply_bundle, propose_bundle
@@ -11,7 +12,12 @@ def test_bundle_apply_happy(mock_wt, tmp_path, monkeypatch):
     )
     mock_wt.return_value = (
         True,
-        {"applied": True, "stage": "done", "lint_ok": True, "tests_ok": True},
+        {
+            "applied": True,
+            "stage": "done",
+            "lint": {"ok": True},
+            "tests": {"ok": True},
+        },
     )
     res = apply_bundle(bid, branch="HEAD")
     assert res["applied"] is True
@@ -30,3 +36,30 @@ def test_bundle_policy_block(mock_wt, tmp_path, monkeypatch):
     res = apply_bundle(bid, branch="HEAD")
     assert res["applied"] is False
     assert res["stage"] == "policy"
+
+
+def test_bundle_qa_failure_returns_details(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    (repo / "a.txt").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "a.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True)
+    monkeypatch.chdir(repo)
+    diff = "--- a/a.txt\n+++ b/a.txt\n@@ -1 +1 @@\n-hello\n+hi\n"
+    bid = propose_bundle([{"file": "a.txt", "diff": diff, "description": ""}])
+    monkeypatch.setattr(
+        "codex_repo_tool.patch.lint_code",
+        lambda: {"ok": False, "stdout": "", "stderr": "lint fail", "code": 1},
+    )
+    monkeypatch.setattr(
+        "codex_repo_tool.patch.run_tests",
+        lambda: {"ok": False, "stdout": "", "stderr": "test fail", "code": 1},
+    )
+    res = apply_bundle(bid, branch="HEAD")
+    assert res["applied"] is False
+    assert res["stage"] == "qa"
+    assert res["lint"]["stderr"] == "lint fail"
+    assert res["tests"]["stderr"] == "test fail"

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,3 +1,4 @@
+import subprocess
 from unittest import mock
 
 from codex_repo_tool.task import run
@@ -60,3 +61,35 @@ def test_task_no_diff(mock_run, tmp_path, monkeypatch):
     res = run(goal="Nothing", auto_pr=False, ask_model_for_diff=lambda g, c: "")
     assert res["ok"] is False
     assert res["stage"] == "plan"
+
+
+def test_task_qa_failure_details(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    (repo / "README.md").write_text(
+        "# CodexRepoTool\n\nUnified, safe, high-level repo operations for AI agents (e.g., Codex).\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        "codex_repo_tool.patch.lint_code",
+        lambda: {"ok": False, "stdout": "", "stderr": "lint fail", "code": 1},
+    )
+    monkeypatch.setattr(
+        "codex_repo_tool.patch.run_tests",
+        lambda: {"ok": False, "stdout": "", "stderr": "test fail", "code": 1},
+    )
+    res = run(
+        goal="Append line to README",
+        auto_pr=False,
+        ask_model_for_diff=lambda g, c: SAMPLE_DIFF,
+    )
+    assert res["ok"] is False
+    assert res["stage"] == "qa"
+    assert res["lint"]["stderr"] == "lint fail"
+    assert res["tests"]["stderr"] == "test fail"


### PR DESCRIPTION
## Summary
- expose lint and test output when bundle application fails
- add regression tests for QA failure details and task propagation

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bff5c13d00832281fbdb9d3dbfa90b